### PR TITLE
add LeafIteratingMutator

### DIFF
--- a/src/main/java/org/aldeon/confgen/Main.java
+++ b/src/main/java/org/aldeon/confgen/Main.java
@@ -15,15 +15,17 @@ import java.util.stream.Collectors;
 public class Main {
 
     private static final Map<String, String> MUTATORS = ImmutableMap.of(
-            "uniform", "org.aldeon.mutator.UniformMutator",
-            "leaf", "org.aldeon.mutator.UniformLeafMutator"
+//            "uniform", "org.aldeon.mutator.UniformMutator",
+//            "leaf", "org.aldeon.mutator.UniformLeafMutator"
+            "leafIterating", "org.aldeon.mutator.LeafIteratingMutator"
+
     );
 
     private static final Set<String> TREES = ImmutableSet.of(
-            "balanced",
-            "furry",
-            "single",
-            "wide"
+//            "balanced",
+//            "furry",
+            "single"
+//            "wide"
     );
 
     private static final Map<Integer, String> SIZES = ImmutableMap.of(
@@ -38,7 +40,8 @@ public class Main {
         for (String tree: TREES) {
             for (Map.Entry<String, String> mutator: MUTATORS.entrySet()) {
                 for (Map.Entry<Integer, String> size: SIZES.entrySet()) {
-                    for (boolean suggests: Lists.newArrayList(true, false)) {
+//                    for (boolean suggests: Lists.newArrayList(true, false)) {
+                        boolean suggests = true;
                         int currentSize = 1;
 
                         while (currentSize < size.getKey()) {
@@ -57,7 +60,7 @@ public class Main {
                             Files.write(Paths.get("config/" + cfgName), Lists.newArrayList(newTemplate), Charsets.UTF_8);
 
                             currentSize *= 2;
-                        }
+//                        }
                     }
                 }
             }

--- a/src/main/java/org/aldeon/mutator/LeafIteratingMutator.java
+++ b/src/main/java/org/aldeon/mutator/LeafIteratingMutator.java
@@ -1,0 +1,29 @@
+package org.aldeon.mutator;
+
+import org.aldeon.model.Forest;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * Created by mb on 28.11.15.
+ */
+public class LeafIteratingMutator implements Mutator {
+    @Override
+    public void mutate(Forest forest, int diffs) {
+        Random r = new Random();
+
+        List<Long> leaves = forest.stream()
+                .filter(n -> forest.withParent(n).isEmpty())
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < diffs; ++i) {
+            long parent = leaves.get(r.nextInt(leaves.size()));
+            long child = r.nextLong();
+            forest.add(parent, child);
+            leaves.remove(parent);
+            leaves.add(child);
+        }
+    }
+}


### PR DESCRIPTION
Added new way of generating tree differences, which consists of adding nodes to random leaves. What makes it different from the existing UniformLeaf is that the set of leaves is recomputed after adding a node.
